### PR TITLE
Refactor/client sub client modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,73 @@
-# futarchy-ts
+# Futarchy TypeScript SDK for The MetaDAO
 
-The Meta-DAO Futarchy Typescript SDK
+The Futarchy TypeScript SDK provides developers with a powerful, easy-to-use interface to interact with futarchy-based Solana programs deployed by The MetaDAO that enabled proposals powered by decision-markets. This SDK abstracts away ,any complexities, allowing developers to manage DAOs, proposals, and token balances with simple, asynchronous function calls.
+
+## Features
+
+- **DAO Management:** Fetch details of all DAOs or a specific DAO within The MetaDAO ecosystem.
+- **Proposals:** Retrieve proposals associated with a DAO, along with their respective vaults.
+- **Token Balances:** Query wallet balances of DAO tokens as well as conditional tokens of proposals for DAO members.
+
+## Installation
+
+To use the Futarchy TypeScript SDK in your project, you'll need to install it via npm or yarn. Ensure you have Node.js installed before proceeding.
+
+```bash
+npm install @themetadao/futarchy-ts
+```
+
+Or install via other package manager like yarn, pnpm, bun, etc.
+
+## Usage
+
+To start using the SDK, you need to import it into your project, along with necessary types from Solana's web3.js library. You can import the RPC client for example. Then you select the AUTOCRAT_VERSION you would like(0 is the latest). AUTOCRAT_VERSION refers to the version of the main Solana program that powers The MetaDAO.
+
+```typescript
+import { PublicKey } from "@solana/web3.js";
+import { FutarchyRPCClient, AUTOCRAT_VERSIONS } from "@themetadao/futarchy-ts";
+```
+
+### Initializing the Client
+
+Now with the goodies imported, initialize the `FutarchyRPCClient`.
+
+```typescript
+const provider = new AnchorProvider(connection, wallet, {});
+const programVersion = AUTOCRAT_VERSIONS[0];
+const client = FutarchyRPCClient.make(programVersion, provider);
+```
+
+### Fetching DAOs
+
+To fetch all DAOs:
+
+```typescript
+const daos = await client.daos.fetchAllDaos();
+```
+
+To fetch a specific DAO by its address:
+
+```typescript
+const daoAddress = "YourDaoAddressHere";
+const dao = await client.daos.fetchDao(daoAddress);
+```
+
+### Working with Proposals
+
+To fetch proposals for a specific DAO:
+
+```typescript
+const proposals = await client.proposals.fetchProposals(dao);
+```
+
+### Managing Token Balances
+
+To fetch main token wallet balances for a DAO member:
+
+```typescript
+const ownerWallet = new PublicKey("YourWalletPublicKeyHere");
+const balances = await client.balances.fetchMainTokenWalletBalances(
+  dao,
+  ownerWallet
+);
+```

--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -1,18 +1,25 @@
 import { PublicKey } from "@solana/web3.js";
 import { DaoAccount, DaoWithTokens, TokenWithBalance } from "../types";
-import { Proposal, ProposalWithVaults } from "../types/proposals";
+import { ProposalWithVaults } from "../types/proposals";
 
 export interface FutarchyClient {
+  daos: FutarchyDaoClient;
+  proposals: FutarchyProposalsClient;
+  balances: FutarchyBalancesClient;
+}
+
+export interface FutarchyDaoClient {
   fetchAllDaos(): Promise<DaoWithTokens[]>;
   fetchDao(daoAddress: string): Promise<DaoWithTokens | undefined>;
+}
+
+export interface FutarchyProposalsClient {
+  fetchProposals(dao: DaoAccount): Promise<ProposalWithVaults[]>;
+}
+
+export interface FutarchyBalancesClient {
   fetchMainTokenWalletBalances(
     dao: DaoWithTokens,
     ownerWallet: PublicKey
-  ): Promise<TokenWithBalance[]>;
-  fetchProposals(dao: DaoAccount): Promise<ProposalWithVaults[]>;
-  fetchAllConditionalTokenWalletBalances(
-    dao: DaoWithTokens,
-    ownerWallet: PublicKey,
-    proposals: ProposalWithVaults[]
   ): Promise<TokenWithBalance[]>;
 }

--- a/lib/client/index.ts
+++ b/lib/client/index.ts
@@ -1,3 +1,3 @@
 export * from "./client";
-export * from "./rpcClient";
-export * from "./indexerClient";
+export * from "./rpc/rpcClient";
+export * from "./indexer/indexerClient";

--- a/lib/client/indexer/balances.ts
+++ b/lib/client/indexer/balances.ts
@@ -1,4 +1,3 @@
-import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import {
   DaoWithTokens,
   TokenWithBalance,

--- a/lib/client/indexer/balances.ts
+++ b/lib/client/indexer/balances.ts
@@ -1,0 +1,32 @@
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import {
+  DaoWithTokens,
+  TokenWithBalance,
+  TokenWithBalanceWithProposal,
+} from "../../types";
+import { FutarchyBalancesClient } from "../client";
+import { PublicKey } from "@solana/web3.js";
+import { ProposalWithVaults } from "../../types/proposals";
+import { Provider } from "@coral-xyz/anchor";
+
+export class FutarchyIndexerBalancesClient implements FutarchyBalancesClient {
+  private rpcProvider: Provider;
+
+  constructor(rpcProvider: Provider) {
+    this.rpcProvider = rpcProvider;
+  }
+
+  async fetchMainTokenWalletBalances(
+    dao: DaoWithTokens,
+    ownerWallet: PublicKey
+  ): Promise<TokenWithBalance[]> {
+    return [];
+  }
+  async fetchAllConditionalTokenWalletBalances(
+    dao: DaoWithTokens,
+    ownerWallet: PublicKey,
+    proposalsWithVaults: ProposalWithVaults[]
+  ): Promise<TokenWithBalanceWithProposal[]> {
+    return [];
+  }
+}

--- a/lib/client/indexer/dao.ts
+++ b/lib/client/indexer/dao.ts
@@ -1,12 +1,5 @@
-import { Program, Provider } from "@coral-xyz/anchor";
-import {
-  AutocratProgram,
-  DaoAccount,
-  DaoWithTokens,
-  ProgramVersion,
-} from "../../types";
+import { DaoAccount, DaoWithTokens } from "../../types";
 import { FutarchyDaoClient } from "../client";
-import { enrichTokenMetadata } from "../../tokens";
 
 export class FutarchyIndexerDaoClient implements FutarchyDaoClient {
   constructor() {}

--- a/lib/client/indexer/dao.ts
+++ b/lib/client/indexer/dao.ts
@@ -1,0 +1,30 @@
+import { Program, Provider } from "@coral-xyz/anchor";
+import {
+  AutocratProgram,
+  DaoAccount,
+  DaoWithTokens,
+  ProgramVersion,
+} from "../../types";
+import { FutarchyDaoClient } from "../client";
+import { enrichTokenMetadata } from "../../tokens";
+
+export class FutarchyIndexerDaoClient implements FutarchyDaoClient {
+  constructor() {}
+  async fetchAllDaos(): Promise<DaoWithTokens[]> {
+    return [];
+  }
+  async fetchDao(daoAddress: string): Promise<DaoWithTokens | undefined> {
+    return undefined;
+  }
+  private async fetchDaoAccount(
+    daoAddress: string
+  ): Promise<DaoAccount | undefined> {
+    return;
+  }
+
+  private async fetchDaoWithTokensFromState(
+    daoAccount: DaoAccount
+  ): Promise<DaoWithTokens | undefined> {
+    return;
+  }
+}

--- a/lib/client/indexer/indexerClient.ts
+++ b/lib/client/indexer/indexerClient.ts
@@ -1,14 +1,20 @@
 import { PublicKey } from "@solana/web3.js";
-import { DaoAccount, DaoWithTokens, TokenWithBalance } from "../types";
-import { FutarchyClient } from "./client";
-import { ProposalWithVaults } from "../types/proposals";
-import { FutarchyRPClient } from "./rpcClient";
+import { DaoAccount, DaoWithTokens, TokenWithBalance } from "../../types";
+import { FutarchyClient } from "../client";
+import { ProposalWithVaults } from "../../types/proposals";
+import { FutarchyRPCClient } from "../rpc/rpcClient";
+import { FutarchyIndexerDaoClient } from "./dao";
+import { FutarchyIndexerProposalsClient } from "./proposals";
+import { FutarchyIndexerBalancesClient } from "./balances";
 
 /**
  * This class is not yet implemented. Use the RPC client for now instead
  */
 export class FutarchyIndexerClient implements FutarchyClient {
-  private rpcClientFallback: FutarchyRPClient;
+  public daos: FutarchyIndexerDaoClient;
+  public proposals: FutarchyIndexerProposalsClient;
+  public balances: FutarchyIndexerBalancesClient;
+  private rpcClientFallback: FutarchyRPCClient;
   //TODO: implement all this
   async fetchAllDaos(): Promise<DaoWithTokens[]> {
     return [];

--- a/lib/client/indexer/proposals.ts
+++ b/lib/client/indexer/proposals.ts
@@ -1,49 +1,9 @@
-import { Program } from "@coral-xyz/anchor";
-import { AutocratProgram, DaoAccount, ProgramVersion } from "../../types";
+import { DaoAccount } from "../../types";
 import { ProposalWithVaults } from "../../types/proposals";
 import { FutarchyProposalsClient } from "../client";
-import { ConditionalVault } from "../../idl/conditional_vault";
-import { VaultAccount } from "../../types/conditionalVault";
 
 export class FutarchyIndexerProposalsClient implements FutarchyProposalsClient {
-  private autocratProgram: Program<AutocratProgram>;
-  private vaultProgram: Program<ConditionalVault>;
-  constructor(
-    autocratProgram: Program<AutocratProgram>,
-    vaultProgram: Program<ConditionalVault>
-  ) {
-    this.autocratProgram = autocratProgram;
-    this.vaultProgram = vaultProgram;
-  }
   async fetchProposals(dao: DaoAccount): Promise<ProposalWithVaults[]> {
-    const allProposals = (
-      await this.autocratProgram.account.proposal.all()
-    ).map((prop) => ({
-      title: `Proposal ${prop.account.number}`,
-      description: "",
-      ...prop,
-    }));
-    const allVaults = await this.vaultProgram.account.conditionalVault.all();
-    const vaultsByAddress: Record<string, VaultAccount> = allVaults.reduce(
-      (prev, curr) => {
-        prev[curr.publicKey.toString()] = curr.account;
-        return prev;
-      },
-      {} as Record<string, VaultAccount>
-    );
-    const proposalsWithVaults: ProposalWithVaults[] = allProposals.map((p) => {
-      const baseVaultAccount = vaultsByAddress[p.account.baseVault.toString()];
-      const quoteVaultAccount =
-        vaultsByAddress[p.account.quoteVault.toString()];
-      return { ...p, baseVaultAccount, quoteVaultAccount };
-    });
-
-    return proposalsWithVaults.filter((p) => {
-      const { baseVaultAccount } = p;
-      return (
-        baseVaultAccount.settlementAuthority.toString() ===
-        dao.treasury.toString()
-      );
-    });
+    return [];
   }
 }

--- a/lib/client/indexer/proposals.ts
+++ b/lib/client/indexer/proposals.ts
@@ -1,0 +1,49 @@
+import { Program } from "@coral-xyz/anchor";
+import { AutocratProgram, DaoAccount, ProgramVersion } from "../../types";
+import { ProposalWithVaults } from "../../types/proposals";
+import { FutarchyProposalsClient } from "../client";
+import { ConditionalVault } from "../../idl/conditional_vault";
+import { VaultAccount } from "../../types/conditionalVault";
+
+export class FutarchyIndexerProposalsClient implements FutarchyProposalsClient {
+  private autocratProgram: Program<AutocratProgram>;
+  private vaultProgram: Program<ConditionalVault>;
+  constructor(
+    autocratProgram: Program<AutocratProgram>,
+    vaultProgram: Program<ConditionalVault>
+  ) {
+    this.autocratProgram = autocratProgram;
+    this.vaultProgram = vaultProgram;
+  }
+  async fetchProposals(dao: DaoAccount): Promise<ProposalWithVaults[]> {
+    const allProposals = (
+      await this.autocratProgram.account.proposal.all()
+    ).map((prop) => ({
+      title: `Proposal ${prop.account.number}`,
+      description: "",
+      ...prop,
+    }));
+    const allVaults = await this.vaultProgram.account.conditionalVault.all();
+    const vaultsByAddress: Record<string, VaultAccount> = allVaults.reduce(
+      (prev, curr) => {
+        prev[curr.publicKey.toString()] = curr.account;
+        return prev;
+      },
+      {} as Record<string, VaultAccount>
+    );
+    const proposalsWithVaults: ProposalWithVaults[] = allProposals.map((p) => {
+      const baseVaultAccount = vaultsByAddress[p.account.baseVault.toString()];
+      const quoteVaultAccount =
+        vaultsByAddress[p.account.quoteVault.toString()];
+      return { ...p, baseVaultAccount, quoteVaultAccount };
+    });
+
+    return proposalsWithVaults.filter((p) => {
+      const { baseVaultAccount } = p;
+      return (
+        baseVaultAccount.settlementAuthority.toString() ===
+        dao.treasury.toString()
+      );
+    });
+  }
+}

--- a/lib/client/indexerClient.ts
+++ b/lib/client/indexerClient.ts
@@ -2,8 +2,13 @@ import { PublicKey } from "@solana/web3.js";
 import { DaoAccount, DaoWithTokens, TokenWithBalance } from "../types";
 import { FutarchyClient } from "./client";
 import { ProposalWithVaults } from "../types/proposals";
+import { FutarchyRPClient } from "./rpcClient";
 
+/**
+ * This class is not yet implemented. Use the RPC client for now instead
+ */
 export class FutarchyIndexerClient implements FutarchyClient {
+  private rpcClientFallback: FutarchyRPClient;
   //TODO: implement all this
   async fetchAllDaos(): Promise<DaoWithTokens[]> {
     return [];

--- a/lib/client/rpc/dao.ts
+++ b/lib/client/rpc/dao.ts
@@ -1,0 +1,63 @@
+import { Program, Provider } from "@coral-xyz/anchor";
+import {
+  AutocratProgram,
+  DaoAccount,
+  DaoWithTokens,
+  ProgramVersion,
+} from "../../types";
+import { FutarchyDaoClient } from "../client";
+import { enrichTokenMetadata } from "../../tokens";
+
+export class FutarchyRPCDaoClient implements FutarchyDaoClient {
+  private autocratProgram: Program<AutocratProgram>;
+  private programVersion: ProgramVersion;
+  private rpcProvider: Provider;
+  constructor(
+    rpcProvider: Provider,
+    programVersion: ProgramVersion,
+    autocratProgram: Program<AutocratProgram>
+  ) {
+    this.rpcProvider = rpcProvider;
+    this.programVersion = programVersion;
+    this.autocratProgram = autocratProgram;
+  }
+  async fetchAllDaos(): Promise<DaoWithTokens[]> {
+    const allDaoAccounts = await this.autocratProgram.account.dao.all();
+    const allDaos: (DaoWithTokens | undefined)[] = await Promise.all(
+      allDaoAccounts.map(async (d) =>
+        this.fetchDaoWithTokensFromState(d.account)
+      )
+    );
+    return allDaos.filter((d): d is DaoWithTokens => !!d);
+  }
+  async fetchDao(daoAddress: string): Promise<DaoWithTokens | undefined> {
+    const daoAccount = await this.fetchDaoAccount(daoAddress);
+    if (daoAccount) {
+      return await this.fetchDaoWithTokensFromState(daoAccount);
+    }
+  }
+  private async fetchDaoAccount(
+    daoAddress: string
+  ): Promise<DaoAccount | undefined> {
+    const daoAccount = await this.autocratProgram.account.dao.fetch(daoAddress);
+    return daoAccount;
+  }
+
+  private async fetchDaoWithTokensFromState(
+    daoAccount: DaoAccount
+  ): Promise<DaoWithTokens | undefined> {
+    const baseMint = ["V0.2", "V0.3"].includes(this.programVersion.label)
+      ? daoAccount.tokenMint
+      : daoAccount.metaMint;
+    const quoteMint = daoAccount.usdcMint;
+    if (baseMint) {
+      const baseToken = await enrichTokenMetadata(baseMint, this.rpcProvider);
+      const quoteToken = await enrichTokenMetadata(quoteMint, this.rpcProvider);
+      return {
+        daoAccount,
+        baseToken,
+        quoteToken,
+      };
+    }
+  }
+}

--- a/lib/client/rpc/proposals.ts
+++ b/lib/client/rpc/proposals.ts
@@ -1,0 +1,49 @@
+import { Program } from "@coral-xyz/anchor";
+import { AutocratProgram, DaoAccount, ProgramVersion } from "../../types";
+import { ProposalWithVaults } from "../../types/proposals";
+import { FutarchyProposalsClient } from "../client";
+import { ConditionalVault } from "../../idl/conditional_vault";
+import { VaultAccount } from "../../types/conditionalVault";
+
+export class FutarchyRPCProposalsClient implements FutarchyProposalsClient {
+  private autocratProgram: Program<AutocratProgram>;
+  private vaultProgram: Program<ConditionalVault>;
+  constructor(
+    autocratProgram: Program<AutocratProgram>,
+    vaultProgram: Program<ConditionalVault>
+  ) {
+    this.autocratProgram = autocratProgram;
+    this.vaultProgram = vaultProgram;
+  }
+  async fetchProposals(dao: DaoAccount): Promise<ProposalWithVaults[]> {
+    const allProposals = (
+      await this.autocratProgram.account.proposal.all()
+    ).map((prop) => ({
+      title: `Proposal ${prop.account.number}`,
+      description: "",
+      ...prop,
+    }));
+    const allVaults = await this.vaultProgram.account.conditionalVault.all();
+    const vaultsByAddress: Record<string, VaultAccount> = allVaults.reduce(
+      (prev, curr) => {
+        prev[curr.publicKey.toString()] = curr.account;
+        return prev;
+      },
+      {} as Record<string, VaultAccount>
+    );
+    const proposalsWithVaults: ProposalWithVaults[] = allProposals.map((p) => {
+      const baseVaultAccount = vaultsByAddress[p.account.baseVault.toString()];
+      const quoteVaultAccount =
+        vaultsByAddress[p.account.quoteVault.toString()];
+      return { ...p, baseVaultAccount, quoteVaultAccount };
+    });
+
+    return proposalsWithVaults.filter((p) => {
+      const { baseVaultAccount } = p;
+      return (
+        baseVaultAccount.settlementAuthority.toString() ===
+        dao.treasury.toString()
+      );
+    });
+  }
+}

--- a/lib/client/rpc/rpcClient.ts
+++ b/lib/client/rpc/rpcClient.ts
@@ -1,0 +1,43 @@
+import { Program, Provider } from "@coral-xyz/anchor";
+import { AutocratProgram, ProgramVersion } from "../../types";
+import { FutarchyClient } from "../client";
+import {
+  ConditionalVault,
+  IDL as ConditionalVaultIDL,
+} from "../../idl/conditional_vault";
+import { autocratVersionToConditionalVaultMap } from "../../constants/conditionalVault";
+import { FutarchyRPCDaoClient } from "./dao";
+import { FutarchyRPCProposalsClient } from "./proposals";
+import { FutarchyRPCBalancesClient } from "./balances";
+
+export class FutarchyRPCClient implements FutarchyClient {
+  public daos: FutarchyRPCDaoClient;
+  public proposals: FutarchyRPCProposalsClient;
+  public balances: FutarchyRPCBalancesClient;
+  private constructor(programVersion: ProgramVersion, rpcProvider: Provider) {
+    const autocratProgram = new Program<AutocratProgram>(
+      programVersion.idl as AutocratProgram,
+      programVersion.programId,
+      rpcProvider
+    );
+
+    const vaultProgram = new Program<ConditionalVault>(
+      ConditionalVaultIDL,
+      autocratVersionToConditionalVaultMap[programVersion.label],
+      rpcProvider
+    );
+    this.daos = new FutarchyRPCDaoClient(
+      rpcProvider,
+      programVersion,
+      autocratProgram
+    );
+    this.proposals = new FutarchyRPCProposalsClient(
+      autocratProgram,
+      vaultProgram
+    );
+    this.balances = new FutarchyRPCBalancesClient(rpcProvider);
+  }
+  static make(programVersion: ProgramVersion, rpcProvider: Provider) {
+    return new FutarchyRPCClient(programVersion, rpcProvider);
+  }
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,9 @@
 import { PublicKey } from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 import { AutocratProgram, ProgramVersion, TokenProps } from "./types";
-const usdcLogo = require("../assets/images/usdc-logo.svg") as string;
+const usdcLogo = require("../assets/images/usdc-logo.svg") as {
+  default: { src: string };
+};
 
 export const OPENBOOK_PROGRAM_ID = new PublicKey(
   "opnb2LAfJYbRMAHHvqjCwQxanZn7ReEHp1k81EohpZb"
@@ -23,7 +25,7 @@ export const USDCMetadata: TokenProps = {
   decimals: 6,
   name: "USD Coin",
   publicKey: "", // depends on network
-  url: usdcLogo,
+  url: usdcLogo.default.src,
 };
 
 export const NUMERAL_FORMAT = "0,0.00";

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,7 @@ import { AutocratV0 as AutocratV0_3 } from "./idl/autocrat_v0.3";
 import { OpenbookTwap } from "./idl/openbook_twap";
 import { OpenbookV2 } from "./idl/openbook_v2";
 import { VaultAccount } from "./types/conditionalVault";
-import { ProposalAccount } from "./types/proposals";
+import { Proposal, ProposalAccount } from "./types/proposals";
 
 export type MergeWithOptionalFields<T, U> = {
   [K in keyof (T | U)]: U[K];
@@ -148,6 +148,10 @@ export type TokenProps = (
 ) & { symbol: string; decimals?: number; name?: string };
 
 export type TokenWithBalance = { token: TokenProps; balance: number };
+
+export type TokenWithBalanceWithProposal = TokenWithBalance & {
+  proposal: PublicKey;
+};
 
 export type DaoWithTokens = {
   daoAccount: DaoAccount;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themetadao/futarchy-ts",
-  "private": "false",
+  "version": "0.0.2-alpha",
   "main": "lib",
   "dependencies": {
     "@coral-xyz/anchor": "^0.28.1-beta.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themetadao/futarchy-ts",
-  "version": "0.0.2-alpha",
+  "version": "1.0.2-alpha",
   "main": "lib",
   "keywords": [
     "solana",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "@themetadao/futarchy-ts",
   "version": "0.0.2-alpha",
   "main": "lib",
+  "keywords": [
+    "solana",
+    "dao",
+    "futarchy",
+    "crypto"
+  ],
   "dependencies": {
     "@coral-xyz/anchor": "^0.28.1-beta.2",
     "@metaplex-foundation/js": "^0.20.1",


### PR DESCRIPTION
- Better readme
- Breaking down client into sub-clients because the client was getting pretty huge and we need to keep adding more methods. This will allow for better collaboration where devs can work on separate sub clients for different data fetching methods.